### PR TITLE
Fix grunt express path error and server reload

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -56,7 +56,9 @@ module.exports = function (grunt) {
       },
       livereload: {
         options: {
+          showStack: true,
           livereload: true,
+          serverreload: true,
           server: path.resolve('app.js'),
           bases: [path.resolve('./.tmp'), path.resolve(__dirname, yeomanConfig.app)]
         }
@@ -265,6 +267,24 @@ module.exports = function (grunt) {
     }
   });
 
+  grunt.task.registerTask('debug-config', 'Debug grunt task configuration.', function(select) {
+    grunt.log.debug('grunt.config: ' + (select ? select + ': ' : '') +
+      JSON.stringify(grunt.config(select), null, 2));
+  });
+
+  grunt.task.registerTask('fix-express-reload', 'Fix express reload watch task.', function(target) {
+    var taskname = 'express_' + target + '_server';
+    var config = grunt.config('watch.' + taskname);
+    if (config) {
+      grunt.log.debug('grunt.config: watch.' + taskname + ' ORIG: ' + JSON.stringify(config, null, 2));
+      config.files = [config.files, 'app.js'];
+      grunt.config('watch.' + taskname + '.files', config.files);
+      grunt.log.debug('grunt.config: watch.' + taskname + ' FIXED: ' + JSON.stringify(config, null, 2));
+    } else {
+      grunt.log.warn('Missing config for watch.' + taskname.cyan + '. Task express:' + target + ' is not running with serverreload:true.');
+    }
+  });
+
   grunt.registerTask('server', function (target) {
     if (target === 'dist') {
       return grunt.task.run(['build', 'open', 'express:dist', 'express-keepalive']);
@@ -274,6 +294,9 @@ module.exports = function (grunt) {
       'clean:server',
       'concurrent:server',
       'express:livereload',
+      // 'debug-config:watch',
+      // 'debug-config:express',
+      'fix-express-reload:livereload',
       'open',
       'watch'
     ]);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -40,7 +40,7 @@
     "connect-livereload": "~0.2.0",
     "grunt-google-cdn": "~0.2.0",
     "grunt-ngmin": "~0.0.2",
-    "grunt-express": "~1.0.0",
+    "grunt-express": "~1.2.1",
     "time-grunt": "~0.1.1"
   }
 }


### PR DESCRIPTION
The auto-generated `watch:express_livereload_server` task only watches the temporary file, not `app.js`.

Has to be resolved at https://github.com/blai/grunt-express/issues/36. 

Workaround https://github.com/tomaash/trackr/pull/1 appends `app.js` to the watched files of specified `watch:express_target_server` task.
